### PR TITLE
Issue #20: Enhanced regex that was used to find a version in a line. …

### DIFF
--- a/src/helpers/checkCLI.js
+++ b/src/helpers/checkCLI.js
@@ -21,7 +21,7 @@ const getVersion = async (rule, context) => {
   
   // Now parse
   const correctLine = getLineWithVersion(rule, versionOutput)
-  const version = removeNonVersionCharacters(correctLine)
+  const version = removeNonVersionCharacters(rule, correctLine)
   return version
 }
 
@@ -46,7 +46,7 @@ const getLineWithVersion = (rule, versionOutput) => {
   return result
 }
 
-const removeNonVersionCharacters = (line) => {
+const removeNonVersionCharacters = (rule, line) => {
   const foundVersions = line.match(/(\d+\.)?(\d+\.)?(\d+)([^\sa-zA-Z0-9]+\w+)?/g)
   // Return longest match, because it is most likely to be correct
   try {

--- a/src/helpers/checkCLI.js
+++ b/src/helpers/checkCLI.js
@@ -49,8 +49,8 @@ const getLineWithVersion = (rule, versionOutput) => {
 const removeNonVersionCharacters = (line) => {
   const foundVersions = line.match(/(\d+\.)?(\d+\.)?(\d+)([^\sa-zA-Z0-9]+\w+)?/g)
   // Return longest match, because it is most likely to be correct
-  let result = foundVersions[0]
   try {
+    var result = foundVersions[0]
     for (let i = 1; i < foundVersions.length; i++) {
       if (foundVersions[i].length >= result.length) {
         result = foundVersions[i]

--- a/src/helpers/checkCLI.js
+++ b/src/helpers/checkCLI.js
@@ -18,15 +18,14 @@ const getVersion = async (rule, context) => {
     }
 
   }
-
+  
   // Now parse
-  const correctLine = getVersionLine(rule, versionOutput)
-  // clean version to only consist of numbers (better than semver.clean)
-  return correctLine.replace(/[^\d.]/g, '')
+  const correctLine = getLineWithVersion(rule, versionOutput)
+  const version = removeNonVersionCharacters(correctLine)
+  return version
 }
 
-// find semver based on rule and output
-const getVersionLine = (rule, versionOutput) => {
+const getLineWithVersion = (rule, versionOutput) => {
   let result
   if (typeof rule.line === 'number') {
     result = versionOutput.split('\n')[rule.line - 1]
@@ -41,16 +40,25 @@ const getVersionLine = (rule, versionOutput) => {
       throw `rule.line string '${rule.line}' was not found`
     }
   } else {
-    // Parse output for something that looks like a version
-    const foundVersions = versionOutput.match(/(\d+\.)?(\d+\.)?(\d+)/g)
-    try {
-      // Always first match (for now...)
-      result = foundVersions[0]
-    } catch (_e) {
-      throw `No version was detected from the output of the binary '${rule.binary}'`
-    }
+    //pass it through if rules don't provide a line
+    result = versionOutput
   }
+  return result
+}
 
+const removeNonVersionCharacters = (line) => {
+  const foundVersions = line.match(/(\d+\.)?(\d+\.)?(\d+)([^\sa-zA-Z0-9]+\w+)?/g)
+  // Return longest match, because it is most likely to be correct
+  let result = foundVersions[0]
+  try {
+    for (let i = 1; i < foundVersions.length; i++) {
+      if (foundVersions[i].length >= result.length) {
+        result = foundVersions[i]
+      }
+    }
+  } catch (_e) {
+    throw `No version was detected from the output of the binary '${rule.binary}'`
+  }
   return result
 }
 


### PR DESCRIPTION
…Use regex always instead of only when rules don't provide a line

In your else in method getVersionLine, you "//Parse output for something that looks like a version" I think you always need to do that, even if they provide a line: num, or a line: "string". Even if they provide the line, there could still be junk in there you need to parse out, which is why you have `return correctLine.replace(/[^\d.]/g, '')` at the end of the getVersion method. It just takes out too much (-beta, and -rc1). It can even grab too much if there is an unrelated number in the same line returned, because that regex blindly keeps all numbers. So I replaced that line with the newly updated regex from getVersionLine so it is always run.

I think the answer is to grow a mature regex. I changed it from `/(\d+\.)?(\d+\.)?(\d+)/g` to `/(\d+\.)?(\d+\.)?(\d+)([^\sa-zA-Z0-9]+\w+)?/g` I attached a screen from regex101 
![image](https://user-images.githubusercontent.com/22359375/31055823-d2f34852-a696-11e7-8010-3da46994ce23.png)
 to show how it behaves. It is possible to simply add \S* to the end, but that will catch some weird things like '2.0.1-' and '2.0.1word', so I decided to make a more exact regex.

Let me know if you oppose any of the changes I've made, and I'll be glad to discuss it with you and update the PR.