### PR TITLE
plugin functionality in place

### DIFF
--- a/src/commands/snapshot.js
+++ b/src/commands/snapshot.js
@@ -1,6 +1,21 @@
 const { propEq, filter, head } = require('ramda')
 const NONE = 'None'
 const DO_NOTHING = 'Nothing to do ¯\\_(ツ)_/¯'
+const runPluginSnapshot = async (runPlugin, context) => {
+  if (typeof runPlugin.snapshot === 'string') {
+    // Just a file copy
+    const { filesystem, system } = context
+    filesystem.copy(
+      runPlugin.snapshot,
+      '.solidarity'
+    )
+    // force local version update
+    await system.run('solidarity snapshot')
+  } else {
+    // run plugin's snapshot function
+    await runPlugin.snapshot(context)
+  }
+}
 
 const createSolidarityFile = async (context) => {
   const { print, printSeparator } = context
@@ -27,8 +42,8 @@ const createSolidarityFile = async (context) => {
       const pluginSpinner = print.spin(`Running ${answer.selectedPlugin} Snapshot`)
       // Config for selected plugin only
       const runPlugin = head(filter(propEq('name', answer.selectedPlugin), context.pluginsList))
-      // run plugin's snapshot function
-      await runPlugin.snapshot(context)
+      // run plugin
+      await runPluginSnapshot(runPlugin, context)
       pluginSpinner.succeed('Snapshot complete')
     }
   } else {

--- a/src/commands/snapshot.js
+++ b/src/commands/snapshot.js
@@ -24,11 +24,12 @@ const createSolidarityFile = async (context) => {
     if (answer.selectedPlugin === NONE) {
       print.info(DO_NOTHING)
     } else {
+      const pluginSpinner = print.spin(`Running ${answer.selectedPlugin} Snapshot`)
       // Config for selected plugin only
       const runPlugin = head(filter(propEq('name', answer.selectedPlugin), context.pluginsList))
-      console.log(runPlugin)
-      // run plugin
-      // run snapshot
+      // run plugin's snapshot function
+      await runPlugin.snapshot(context)
+      pluginSpinner.succeed('Snapshot complete')
     }
   } else {
     print.error(`No solidarity plugins found!


### PR DESCRIPTION
### 2 subsequent runs of `solidarity snapshot` for success!!!!! 🎉 
![image](https://user-images.githubusercontent.com/997157/31312654-8a623e66-ab8e-11e7-970c-2e899589f19c.png)

Notes about this PR:
1. The plugin I'm using was added to node-modules via `yarn add <local path>`
1. The plugin is here:  https://github.com/infinitered/solidarity-react-native
1. Most of the time, I assume the user will simply copy a file of the rules, and then run snapshot to update versions inside the file to match the system.   Since this is common, maybe I make that easier for plugin authors?   Maybe just pass a string of the filename that is the template and let the CLI base take care of the rest?