### PR TITLE
Fix typo in yarn install

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Node.js version must be >= `7.6.0`.
 $ npm i -g solidarity solidarity-react-native
 
 # example of installing local with yarn and elixir snapshot (dev dependencies)
-$ yarn add soliarity solidarity-elixir --dev
+$ yarn add solidarity solidarity-elixir --dev
 ```
 
 ## How do I use it?


### PR DESCRIPTION
There is a typo in the yarn install instructions