### PR TITLE
Modified output and added options as discussed in #85

### DIFF
--- a/__tests__/command_helpers/checkCLI.ts
+++ b/__tests__/command_helpers/checkCLI.ts
@@ -27,9 +27,7 @@ test('fine on existing binary', async () => {
 test('returns message on improper version', async () => {
   solidarityExtension(context)
   context.solidarity.getVersion = () => '1'
-  const message = `This system has an improper version for ${outOfDateCLI.binary}:
-        Rule='${outOfDateCLI.semver}'
-        Actual='1'`
+  const message = `${outOfDateCLI.binary}: you have '1', but the project requires '${outOfDateCLI.semver}'`
 
   expect(await checkCLI(outOfDateCLI, context)).toBe(message)
 })

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,6 +1,21 @@
 # Solidarity Options
 Understanding the `.solidarity` file helps you read and write new solidarity checks for any project.
 
+## Solidarity output
+You can use set the following option in `.solidarity` to configure output:
+```
+{
+  "config" : {
+    "output" : "<moderate/verbose/silent>" // Default is moderate
+  }
+}
+```
+- Moderate - Only outputs message if a specific check fails
+- Verbose  - Outputs messages for successful and failed checks.
+- Silent   - Only outputs the final result for all checks (Pass/Fail)
+
+Optionally you can also pass `--verbose` in the CLI to override the configuration option and output all status messages.
+
 ## Solidarity Rules
 The `.solidarity` file is a JSON object with a set of requirements to enforce on each computer's environment.  All requirements should be specified inside the `requirements` key.
 

--- a/src/extensions/functions/checkCLI.ts
+++ b/src/extensions/functions/checkCLI.ts
@@ -20,9 +20,7 @@ module.exports = async (rule: SolidarityRule, context: SolidarityRunContext): Pr
 
     // I can't get no satisfaction
     if (!semver.satisfies(binarySemantic, rule.semver)) {
-      return `This system has an improper version for ${rule.binary}:
-        Rule='${rule.semver}'
-        Actual='${binaryVersion}'`
+      return `${rule.binary}: you have '${binaryVersion}', but the project requires '${rule.semver}'`
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export interface SolidarityRunContext extends GluegunRunContext {
   _pluginsList: Array<SolidarityPlugin & {templateDirectory: string}>
   addPlugin: (config: SolidarityPlugin) => void
   printSeparator: () => void
+  outputMode : SolidarityOutputMode
 }
 
 export type SnapshotType = (context: SolidarityRunContext) => Promise<void>
@@ -48,4 +49,11 @@ export type SolidarityRequirement = SolidarityRule[]
 
 export interface SolidaritySettings {
   requirements: object
+  config : object
+}
+
+export enum SolidarityOutputMode {
+  MODERATE,
+  VERBOSE,
+  SILENT
 }


### PR DESCRIPTION
Github issue #85

I wasn't sure on the following things:
- If the `"config" { "output" : "value" }` tree is redundant and should the `output` be on the top level of the config
- If how the output works should be changed (printing a final message even on `silent`)
- The documentation is in the correct place

Let me know what you think!