### PR TITLE
Add some files to .npmignore to clean up published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,8 @@
 _art/
 .solidarity.example.json
-tests/
+__tests__/
 src/
 .node-version
+coverage/
+yarn.lock
+*.log


### PR DESCRIPTION
Actually in `solidarity@1.0.0` there are several unwanted files that have been published with npm.

```
127 KB   __tests__
700 KB   coverage
184 KB   yarn-error.log
171 KB   yarn.lock
```

Let's just removed them, we'll have a package of 295 KB instead of 1.5 MB :tada: