### PR TITLE
Kill sneaky null

### DIFF
--- a/__tests__/command_helpers/checkCLIForUpdates.ts
+++ b/__tests__/command_helpers/checkCLIForUpdates.ts
@@ -2,10 +2,15 @@ import checkCLIForUpdates from '../../src/extensions/functions/checkCLIForUpdate
 
 import context from 'gluegun'
 const rule = {
-  rule: "cli",
-  binary: "bananas",
-  semver: "1.1.0",
-  version: "--version"
+  rule: 'cli',
+  binary: 'bananas',
+  semver: '1.1.0',
+  version: '--version'
+}
+
+const ruleNoSemver = {
+  rule: 'cli',
+  binary: 'yarn'
 }
 
 describe('checkCLIForUpdates', () => {
@@ -18,7 +23,7 @@ describe('checkCLIForUpdates', () => {
 
   describe('with a good binary', () => {
     beforeEach(() => {
-      rule.binary = "yarn"
+      rule.binary = 'yarn'
       context.print = {
         color: {
           green: jest.fn((string) => string)
@@ -33,6 +38,16 @@ describe('checkCLIForUpdates', () => {
 
       const result = await checkCLIForUpdates(rule, context)
       expect(result).toEqual("Setting yarn to '1.0'")
+    })
+
+    it('does nothing if there was no original semver', async () => {
+      context.solidarity = {
+        getVersion: jest.fn(() => '1.0')
+      }
+
+      const result = await checkCLIForUpdates(ruleNoSemver, context)
+      expect(result).toEqual(undefined)
+      expect(ruleNoSemver.semver).toBe(undefined)
     })
   })
 })

--- a/__tests__/command_helpers/checkDir.ts
+++ b/__tests__/command_helpers/checkDir.ts
@@ -17,3 +17,7 @@ test('checkDir returns false for a file that exists', () => {
   // Use checkDir to make sure a known file returns false since it's not a directory
   expect(checkDir({location: './package.json'}, context)).toBeFalsy()
 })
+
+test('checkDir returns false if no location is set', () => {
+  expect(checkDir({}, context)).toBeFalsy()
+})

--- a/__tests__/command_helpers/checkENV.ts
+++ b/__tests__/command_helpers/checkENV.ts
@@ -22,3 +22,7 @@ test('checkENV can fail', async () => {
   // Use checkENV to make sure it exists
   expect(await checkENV({variable: 'THIS_SHOULD_NOT_EXIST_VERIFIER'})).toBeFalsy()
 })
+
+test('checkENV fails if no variable is set', async () => {
+  expect(await checkENV({})).toBeFalsy()
+})

--- a/__tests__/command_helpers/checkFile.ts
+++ b/__tests__/command_helpers/checkFile.ts
@@ -13,7 +13,11 @@ test('checkFile can fail', () => {
   expect(checkFile({location: 'DOES_NOT_EXIST'}, context)).toBeFalsy()
 })
 
-test('checkFile returns false for a file that exists', () => {
+test('checkFile returns false for a dir that exists', () => {
   // Use checkFile to make sure a known dir returns false since it's not a file
   expect(checkFile({location: './src'}, context)).toBeFalsy()
+})
+
+test('checkFile returns false with no location', () => {
+  expect(checkFile({}, context)).toBeFalsy()
 })

--- a/__tests__/command_helpers/getLineWithVersion.ts
+++ b/__tests__/command_helpers/getLineWithVersion.ts
@@ -3,26 +3,26 @@ import getInLineWithVersion from '../../src/extensions/functions/getLineWithVers
 describe('getLineWithVersion', () => {
   test('line: number', () => {
     const rule = {
-        rule: "cli",
-        binary: "node",
-        semver: ">=7.6.0", 
-        error: "Upgrade to latest node >= 7.6 please.",
-        number: 'this',
-        line: 2
+      rule: 'cli',
+      binary: 'node',
+      semver: '>=7.6.0',
+      error: 'Upgrade to latest node >= 7.6 please.',
+      number: 'this',
+      line: 2
     }
 
     const versionOutput = `Node js \n 7.6.0`
     const result = getInLineWithVersion(rule, versionOutput)
 
-    expect(result).toEqual(" 7.6.0")
+    expect(result).toEqual(' 7.6.0')
   })
 
   test('line: string', () => {
     const rule = {
-      rule: "cli",
-      binary: "node",
-      semver: ">=7.6.0", 
-      error: "Upgrade to latest node >= 7.6 please.",
+      rule: 'cli',
+      binary: 'node',
+      semver: '>=7.6.0',
+      error: 'Upgrade to latest node >= 7.6 please.',
       number: 'this',
       line: 'version:'
     }
@@ -30,15 +30,15 @@ describe('getLineWithVersion', () => {
     const versionOutput = `Node js \n version: 7.6.0`
     const result = getInLineWithVersion(rule, versionOutput)
 
-    expect(result).toEqual(" version: 7.6.0")
+    expect(result).toEqual(' version: 7.6.0')
   })
 
   test('no line', () => {
     const rule = {
-      rule: "cli",
-      binary: "node",
-      semver: ">=7.6.0", 
-      error: "Upgrade to latest node >= 7.6 please.",
+      rule: 'cli',
+      binary: 'node',
+      semver: '>=7.6.0',
+      error: 'Upgrade to latest node >= 7.6 please.',
       number: 'this'
     }
 

--- a/src/commands/solidarity.ts
+++ b/src/commands/solidarity.ts
@@ -30,8 +30,8 @@ namespace Solidarity {
     }
 
     // Set output mode, set to default on invalid value
-    let outputModeString = settings.config ? String(settings.config.output).toUpperCase() : null
-    return SolidarityOutputMode[outputModeString] || SolidarityOutputMode.MODERATE
+    let outputModeString = settings.config ? String(settings.config.output).toUpperCase() : SolidarityOutputMode.MODERATE
+    return SolidarityOutputMode[outputModeString]
   }
 
   export const run = async (context) => {

--- a/src/extensions/functions/checkCLI.ts
+++ b/src/extensions/functions/checkCLI.ts
@@ -1,5 +1,5 @@
 import { SolidarityRunContext, SolidarityRule } from '../../types'
-module.exports = async (rule: SolidarityRule, context: SolidarityRunContext): Promise<string> => {
+module.exports = async (rule: SolidarityRule, context: SolidarityRunContext): Promise<string | undefined> => {
   const { semver, solidarity } = context
   const binaryExists = require('./binaryExists')
 

--- a/src/extensions/functions/checkCLIForUpdates.ts
+++ b/src/extensions/functions/checkCLIForUpdates.ts
@@ -1,13 +1,15 @@
 import { SolidarityRule, SolidarityRunContext } from '../../types'
-module.exports = async (rule: SolidarityRule, context: SolidarityRunContext): Promise<string> => {
+module.exports = async (rule: SolidarityRule, context: SolidarityRunContext): Promise<string | undefined> => {
   const { system, semver, solidarity, print } = context
   const { color } = print
 
-  // First check for binary
-  try {
-    system.which(rule.binary)
-  } catch (_e) {
-    return `Binary '${rule.binary}' not found`
+  // If binary is set but not found
+  if (rule.binary) {
+    try {
+      system.which(rule.binary)
+    } catch (_e) {
+      return `Binary '${rule.binary}' not found`
+    }
   }
 
   const binaryVersion = await solidarity.getVersion(rule, context)
@@ -16,8 +18,8 @@ module.exports = async (rule: SolidarityRule, context: SolidarityRunContext): Pr
   let binarySemantic = binaryVersion
   while (binarySemantic.split('.').length < 3) { binarySemantic += '.0' }
 
-  // If it doesn't satisfy, upgrade
-  if (!semver.satisfies(binarySemantic, rule.semver)) {
+  // if it doesn't satisfy, upgrade
+  if (rule.semver && !semver.satisfies(binarySemantic, rule.semver)) {
     rule.semver = binaryVersion
     return color.green(`Setting ${rule.binary} to '${binaryVersion}'`)
   }

--- a/src/extensions/functions/checkDir.ts
+++ b/src/extensions/functions/checkDir.ts
@@ -1,5 +1,9 @@
 import { SolidarityRule, SolidarityRunContext } from '../../types'
 module.exports = (rule: SolidarityRule, context: SolidarityRunContext): boolean => {
   const {filesystem} = context
-  return filesystem.exists(rule.location) === 'dir'
+  if (rule.location) {
+    return filesystem.exists(rule.location) === 'dir'
+  } else {
+    return false
+  }
 }

--- a/src/extensions/functions/checkENV.ts
+++ b/src/extensions/functions/checkENV.ts
@@ -1,4 +1,5 @@
 import { SolidarityRule, SolidarityRunContext } from '../../types'
-module.exports = (rule: SolidarityRule, context: SolidarityRunContext): string => {
-  return process.env[rule.variable]
+module.exports = (rule: SolidarityRule, context: SolidarityRunContext): string | undefined => {
+  const envVar = rule.variable || ''
+  return process.env[envVar]
 }

--- a/src/extensions/functions/checkFile.ts
+++ b/src/extensions/functions/checkFile.ts
@@ -1,5 +1,9 @@
 import { SolidarityRule, SolidarityRunContext } from '../../types'
 module.exports = (rule: SolidarityRule, context: SolidarityRunContext): boolean => {
   const {filesystem} = context
-  return filesystem.exists(rule.location) === 'file'
+  if (rule.location) {
+    return filesystem.exists(rule.location) === 'file'
+  } else {
+    return false
+  }
 }

--- a/src/extensions/functions/getLineWithVersion.ts
+++ b/src/extensions/functions/getLineWithVersion.ts
@@ -7,10 +7,10 @@ module.exports = (rule: SolidarityRule, versionOutput: string): string => {
     const findString = `.*${rule.line}.*`
     const findRegex = RegExp(findString, 'g')
     const foundLines = versionOutput.match(findRegex)
-    try {
+    if (Array.isArray(foundLines)) {
       // Always first instance
       result = foundLines[0]
-    } catch (_e) {
+    } else {
       throw `rule.line string '${rule.line}' was not found`
     }
   } else {

--- a/src/extensions/functions/removeNonVersionCharacters.ts
+++ b/src/extensions/functions/removeNonVersionCharacters.ts
@@ -1,10 +1,11 @@
 import { SolidarityRule } from '../../types'
 module.exports = (rule: SolidarityRule, line: string): string => {
   const foundVersions = line.match(/(\d+\.)?(\d+\.)?(\d+)([^\sa-zA-Z0-9]+\w+)?/g)
-  try {
+
+  if (Array.isArray(foundVersions)) {
     const matchIndex = rule.matchIndex || 0
     return foundVersions[matchIndex]
-  } catch (_e) {
+  } else {
     throw ` No version was detected from the output of the binary '${rule.binary}'`
   }
 }

--- a/src/extensions/functions/skipRule.ts
+++ b/src/extensions/functions/skipRule.ts
@@ -5,8 +5,7 @@ module.exports = (platform: string | string[]): boolean => {
     platform = (platform === 'windows') ? 'win32' : platform
     platform = (platform === 'macos') ? 'darwin' : platform
     return platform !== process.platform
-  } else if (typeof platform === 'object' && platform.length > 0) {
-    // it's an array
+  } else if (Array.isArray(platform)) {
     platform.map((p) => p.toLowerCase())
     const winIndex = platform.indexOf('windows')
     const macIndex = platform.indexOf('macos')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,10 @@
     "types": ["node"],
 
     // Let's allow `import`
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+
+    // Don't let sneaky null/undefined through
+    "strictNullChecks": true
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
I flipped on this setting for TSConfig
![image](https://user-images.githubusercontent.com/997157/32664787-e8cacf1c-c5f7-11e7-93c7-c52c0ace2901.png)

Rewrote the code it bitched about and added tests.  I'm happy with the results.  `undefined` is acknowledged in the places where I use it, but if someone tries to sneak in a `null | undefined` we'll be ready!
