### PR TITLE
🔧 Teaches jest about source maps and thresholds

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "tslint -p .",
     "newclear": "rm -rf node_modules && yarn && tsc",
     "watch": "jest --watch",
-    "coverage": "jest --coverage",
+    "coverage": "jest --no-cache --ci --coverage",
     "snapupdate": "jest -u",
     "welcome": "yarn tsc && npm link",
     "serve:docs": "docsify serve docs"
@@ -59,6 +59,15 @@
     "testPathIgnorePatterns": [
       "__mocks__"
     ],
+    "coverageThreshold": {
+      "global": {
+        "statements": 84,
+        "branches": 77,
+        "lines": 85,
+        "functions": 81
+      }
+    },
+    "mapCoverage": true,
     "moduleFileExtensions": [
       "ts",
       "tsx",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,9 +21,10 @@
     "allowSyntheticDefaultImports": true,
 
     // Don't let sneaky null/undefined through
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "sourceMap": true
   },
   "include": [
-    "./src/**/*"
+    "src"
   ]
 }


### PR DESCRIPTION
### Coverage + Source Maps

Jest needs to be told to use source maps with the `mapCoverage: true` in `package.json` or via `--mapCoverage` on the command line.

I also turned on external source maps in `tsconfig.json` as well.

### --no-cache --ci

For `yarn coverage`, I turned off caching and other optimizations to go with a vanilla/from-scratch run.  It's "safer" but slower.

### Coverage Thresholds

Now that source maps work with jest, your coverage score went up!  🎉 

I locked each of the scores in to what they are now.  You can adjust these to your own goals and comfort levels in `package.json` > `jest` > `coverageThreshold` > `global`.


