### PR TITLE
:raised_hands: lint change and expose envinfo

### DIFF
--- a/src/extensions/functions/solidarityReport.ts
+++ b/src/extensions/functions/solidarityReport.ts
@@ -13,7 +13,7 @@ export const createReport = (context: SolidarityRunContext): SolidarityReportRes
     shellRules: [['Command', 'Pattern', 'Matches']],
     customRules: [],
     // helper for adding CLI rules
-    addCLI: function (cliReportConfig: CLIReportConfig) {
+    addCLI: function(cliReportConfig: CLIReportConfig) {
       const desired = cliReportConfig.desired ? cliReportConfig.desired : colors.green('*ANY*')
       let location
       try {

--- a/src/extensions/solidarity-extension.ts
+++ b/src/extensions/solidarity-extension.ts
@@ -1,4 +1,5 @@
 import { SolidarityRunContext, solidarity, SolidarityPlugin } from '../types'
+import { helpers } from 'envinfo'
 
 const callsite = require('callsite')
 const path = require('path')
@@ -22,6 +23,9 @@ module.exports = (context: SolidarityRunContext): void => {
       ...pluginConfig,
     })
   }
+
+  // Add helpers
+  context.envHelpers = helpers
 
   // Flavored separator
   context.printSeparator = (): void =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export interface SolidarityRunContext extends GluegunRunContext {
   addPlugin: (config: SolidarityPlugin) => void
   printSeparator: () => void
   outputMode: SolidarityOutputMode
+  envHelpers: any
 }
 
 export type SnapshotType = (context: SolidarityRunContext) => Promise<void>

--- a/tslint.json
+++ b/tslint.json
@@ -2,6 +2,7 @@
   "extends": "tslint-config-standard",
   "rules": {
     "trailing-comma": [true],
-    "no-string-throw": false
+    "no-string-throw": false,
+    "space-before-function-paren": false
   }
 }


### PR DESCRIPTION
envinfo now exposed on solidarity.  To be used on upcoming plugins!

( @tabrindle -  I couldn't access it via require, so now I'm affixing it. )


Also, this fixes the Standard vs Prettier fight.
https://github.com/prettier/prettier/issues/1139