### PR TITLE
⚒ Upgrades to the latest Gluegun beta

### DIFF
--- a/__tests__/__mocks__/mockContext.ts
+++ b/__tests__/__mocks__/mockContext.ts
@@ -1,4 +1,4 @@
-const realThing = require('gluegun')
+const realThing = require('gluegun/toolbox')
 const realSolidarityContext = require('../../src/extensions/solidarity-extension')
 realSolidarityContext(realThing)
 
@@ -51,7 +51,7 @@ const mockContext = {
   },
   prompt: {
     ask: jest.fn(({ name }) => Promise.resolve({ [name]: 'taco', createFile: true })),
-    confirm: jest.fn(() => true)
+    confirm: jest.fn(() => true),
   },
   solidarity: noConfigSolidarity,
 }

--- a/__tests__/command_helpers/binaryExists.ts
+++ b/__tests__/command_helpers/binaryExists.ts
@@ -1,5 +1,5 @@
 import binaryExists from '../../src/extensions/functions/binaryExists'
-import context from 'gluegun'
+import * as context from 'gluegun/toolbox'
 
 const doesNotExistCLI = 'no_way_this_should_be_real'
 const alwaysExistCLI = 'node'

--- a/__tests__/command_helpers/checkCLI.ts
+++ b/__tests__/command_helpers/checkCLI.ts
@@ -14,7 +14,7 @@ const outOfDateCLI = {
   semver: '10.99',
 }
 
-const context = require('gluegun')
+const context = require('gluegun/toolbox')
 
 test('error on missing binary', async () => {
   expect(await checkCLI(doesNotExistCLI, context)).toBe(`Binary '${doesNotExistCLI.binary}' not found`)

--- a/__tests__/command_helpers/checkCLIForUpdates.ts
+++ b/__tests__/command_helpers/checkCLIForUpdates.ts
@@ -1,6 +1,6 @@
 import checkCLIForUpdates from '../../src/extensions/functions/checkCLIForUpdates'
 
-import context from 'gluegun'
+import * as context from 'gluegun/toolbox'
 const rule = {
   rule: 'cli',
   binary: 'bananas',

--- a/__tests__/command_helpers/checkDir.ts
+++ b/__tests__/command_helpers/checkDir.ts
@@ -1,5 +1,5 @@
 import checkDir from '../../src/extensions/functions/checkDir'
-import context from 'gluegun'
+import * as context from 'gluegun/toolbox'
 
 test('checkDir detects an existing dir', () => {
   // Check for a known directory

--- a/__tests__/command_helpers/checkFile.ts
+++ b/__tests__/command_helpers/checkFile.ts
@@ -1,5 +1,5 @@
 import checkFile from '../../src/extensions/functions/checkFile'
-import context from 'gluegun'
+import * as context from 'gluegun/toolbox'
 
 test('checkFile detects an existing file', () => {
   // known file

--- a/__tests__/command_helpers/checkRequirement.ts
+++ b/__tests__/command_helpers/checkRequirement.ts
@@ -1,6 +1,6 @@
 import { SolidarityRequirement } from '../../dist/types'
 import { toPairs } from 'ramda'
-import { strings } from 'gluegun'
+import { strings } from 'gluegun/toolbox'
 
 import checkRequirement from '../../src/extensions/functions/checkRequirement'
 import solidarityExtension from '../../src/extensions/solidarity-extension'
@@ -21,7 +21,7 @@ const checkENV = require('../../src/extensions/functions/checkENV')
 jest.mock('../../src/extensions/functions/checkFile')
 const checkFile = require('../../src/extensions/functions/checkFile')
 
-const context = require('gluegun')
+const context = require('gluegun/toolbox')
 
 const badRule = toPairs({
   YARN: [{ rule: 'knope', binary: 'yarn' }],

--- a/__tests__/command_helpers/checkShell.ts
+++ b/__tests__/command_helpers/checkShell.ts
@@ -1,5 +1,5 @@
 import { ShellRule, SolidarityRunContext } from '../../src/types'
-import { strings } from 'gluegun'
+import { strings } from 'gluegun/toolbox'
 const checkShell: any = require('../../src/extensions/functions/checkShell')
 
 /**

--- a/__tests__/command_helpers/createPlugin.ts
+++ b/__tests__/command_helpers/createPlugin.ts
@@ -6,7 +6,6 @@ test('check result shape', () => {
 })
 
 test('investigate createPlugin', async () => {
-
   const result = await createPlugin(context)
   expect(result).toMatchSnapshot()
   expect(context.template.generate).toBeCalled()

--- a/__tests__/command_helpers/getSolidaritySettings.ts
+++ b/__tests__/command_helpers/getSolidaritySettings.ts
@@ -1,7 +1,7 @@
 import { solidarity } from '../../src'
 import getSolidaritySettings from '../../src/extensions/functions/getSolidaritySettings'
 
-const context = require('gluegun')
+const context = require('gluegun/toolbox')
 
 describe('getSolidaritySettings', () => {
   describe('w/ success', () => {

--- a/__tests__/command_helpers/getVersion.ts
+++ b/__tests__/command_helpers/getVersion.ts
@@ -2,7 +2,7 @@ import getVersion from '../../src/extensions/functions/getVersion'
 
 import solidarityExtension from '../../src/extensions/solidarity-extension'
 
-const context = require('gluegun')
+const context = require('gluegun/toolbox')
 let originalTimeout
 solidarityExtension(context)
 
@@ -13,7 +13,7 @@ describe('getVersion', () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000
   })
 
-  afterAll(function() {
+  afterAll(function () {
     // Fix timeout change
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout
   })

--- a/__tests__/commands/create.ts
+++ b/__tests__/commands/create.ts
@@ -13,7 +13,7 @@ it('enforces required properties', () => {
 
 test('check solidarity create with no parameter', async () => {
   const result = await createCommand.run(mockContext)
-  expect(mockContext.print.error.mock.calls).toEqual([["Missing what to create"], ["solidarity create <wut?>"]])
+  expect(mockContext.print.error.mock.calls).toEqual([['Missing what to create'], ['solidarity create <wut?>']])
   expect(mockContext.print.info.mock.calls.length).toBe(1)
 })
 
@@ -21,14 +21,16 @@ test('check solidarity create with plugin', async () => {
   const goodContext = {
     ...mockContext,
     parameters: { first: 'plugin' },
-    solidarity: { createPlugin: jest.fn() }
+    solidarity: { createPlugin: jest.fn() },
   }
   await createCommand.run(goodContext)
   expect(goodContext.solidarity.createPlugin).toBeCalled()
 
   // now make it fail
   const errorString = 'ER MA GERD ARRAWRS'
-  goodContext.solidarity.createPlugin = jest.fn(() => throw Error(errorString))
+  goodContext.solidarity.createPlugin = jest.fn(() => {
+    throw Error(errorString)
+  })
   await createCommand.run(goodContext)
   expect(goodContext.print.error.mock.calls.slice(-1).toString()).toEqual(`Error: ${errorString}`)
 })

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "callsite": "^1.0.0",
     "envinfo": "^4.0.0-beta.5",
-    "gluegun": "2.0.0-beta.6",
+    "gluegun": "2.0.0-beta.7",
     "json5": "^0.5.1",
     "minimist": "^1.2.0",
     "ramda": "0.25.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "callsite": "^1.0.0",
     "envinfo": "^4.0.0-beta.5",
-    "gluegun": "^2.0.0-beta.4",
+    "gluegun": "2.0.0-beta.6",
     "json5": "^0.5.1",
     "minimist": "^1.2.0",
     "ramda": "0.25.0"

--- a/src/commands/snapshot.ts
+++ b/src/commands/snapshot.ts
@@ -8,8 +8,10 @@ namespace Snapshot {
     if (typeof runPlugin.snapshot === 'string') {
       // Just a file copy
       const { filesystem, system } = context
+      // @ts-ignore -- strictNullChecks strikes
       filesystem.copy(`${runPlugin.templateDirectory}${runPlugin.snapshot}`, '.solidarity')
       // force local version update
+      // @ts-ignore -- strictNullChecks strikes
       await system.run('solidarity snapshot')
     } else {
       // run plugin's snapshot function

--- a/src/extensions/functions/createPlugin.ts
+++ b/src/extensions/functions/createPlugin.ts
@@ -14,7 +14,7 @@ module.exports = async context => {
   const description = await prompt.ask({
     type: 'input',
     name: 'pluginDesc',
-    message: 'Short plugin description (used in various places)'
+    message: 'Short plugin description (used in various places)',
   })
 
   const ruleChoices = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,16 @@
-import { GluegunRunContext } from 'gluegun'
+import {
+  GluegunRunContext,
+  GluegunFilesystem,
+  GluegunStrings,
+  GluegunPrint,
+  GluegunSystem,
+  GluegunSemver,
+  GluegunHttp,
+  GluegunPatching,
+  GluegunPrompt,
+  GluegunTemplate,
+  GluegunMeta,
+} from 'gluegun'
 export const solidarity = {
   binaryExists: require('./extensions/functions/binaryExists'),
   getSolidaritySettings: require('./extensions/functions/getSolidaritySettings'),
@@ -35,6 +47,16 @@ export interface SolidarityRunContext extends GluegunRunContext {
   printSeparator: () => void
   outputMode: SolidarityOutputMode
   envHelpers: any
+  filesystem: GluegunFilesystem
+  strings: GluegunStrings
+  print: GluegunPrint
+  system: GluegunSystem
+  semver: GluegunSemver
+  http: GluegunHttp
+  patching: GluegunPatching
+  prompt: GluegunPrompt
+  template: GluegunTemplate
+  meta: GluegunMeta
 }
 
 export type SnapshotType = (context: SolidarityRunContext) => Promise<void>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,24 +2,25 @@
   "compilerOptions": {
     // Brings in Promise and all es2015 extensions to TS
     // TODO: Bringing in dom to quell URL issue, please remove if possible
-    "lib": ["es2015", "dom", "es7"],
+    "lib": [
+      "es2015",
+      "dom",
+      "es7"
+    ],
     "outDir": "dist",
-
     // Emits types for others to consume
     "declaration": true,
     "declarationDir": "dist/types",
-
     // Using commonjs here to play nice with node (imports not welcome here)
     "module": "commonjs",
     "target": "es6",
     "moduleResolution": "node",
-
     // Help TS understand node globals
-    "types": ["node"],
-
+    "types": [
+      "node"
+    ],
     // Let's allow `import`
     "allowSyntheticDefaultImports": true,
-
     // Don't let sneaky null/undefined through
     "strictNullChecks": true,
     // Yes plz

--- a/yarn.lock
+++ b/yarn.lock
@@ -2444,8 +2444,8 @@ fs-extra@~0.6.4:
     rimraf "~2.2.0"
 
 fs-jetpack@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fs-jetpack/-/fs-jetpack-1.2.0.tgz#feb20b44bf3725492827cd2f81a7c812423882c5"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fs-jetpack/-/fs-jetpack-1.3.0.tgz#17f9d95047ac261667d72818a772d2e5125f4281"
   dependencies:
     minimatch "^3.0.2"
 
@@ -2618,9 +2618,9 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-gluegun@2.0.0-beta.6:
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/gluegun/-/gluegun-2.0.0-beta.6.tgz#617d7c43648a8dd058b0497f8fc3e3c541c9f3c2"
+gluegun@2.0.0-beta.7:
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/gluegun/-/gluegun-2.0.0-beta.7.tgz#59a9f832d33da53bfab66afe2cf523d738a77384"
   dependencies:
     apisauce "0.14.3"
     app-module-path "^2.2.0"
@@ -3279,8 +3279,8 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
 is-windows@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -4498,8 +4498,8 @@ minimist@~0.0.1:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mixin-deep@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.0.tgz#47a8732ba97799457c8c1eca28f95132d7e8150a"
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1412,13 +1412,13 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cosmiconfig@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-3.1.0.tgz#640a94bf9847f321800403cd273af60665c73397"
+cosmiconfig@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-4.0.0.tgz#760391549580bbd2df1e562bc177b13c290972dc"
   dependencies:
     is-directory "^0.3.1"
     js-yaml "^3.9.0"
-    parse-json "^3.0.0"
+    parse-json "^4.0.0"
     require-from-string "^2.0.1"
 
 coveralls@^3.0.0:
@@ -1470,11 +1470,21 @@ create-thenable@~1.0.0:
     object.omit "~2.0.0"
     unique-concat "~0.2.2"
 
-cross-spawn@^5.0.1, cross-spawn@^5.1.0:
+cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
     lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.4.tgz#bbf44ccb30fb8314a08f178b62290c669c36d808"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
 
@@ -2608,19 +2618,19 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-gluegun@^2.0.0-beta.4:
-  version "2.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/gluegun/-/gluegun-2.0.0-beta.4.tgz#e0d51b9214ae0ccc6296649295f36c07e0d1a0ac"
+gluegun@2.0.0-beta.6:
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/gluegun/-/gluegun-2.0.0-beta.6.tgz#617d7c43648a8dd058b0497f8fc3e3c541c9f3c2"
   dependencies:
     apisauce "0.14.3"
     app-module-path "^2.2.0"
     cli-table2 "^0.2.0"
     colors "^1.1.2"
-    cosmiconfig "^3.1.0"
-    cross-spawn "^5.1.0"
+    cosmiconfig "^4.0.0"
+    cross-spawn "^6.0.4"
     ejs "^2.5.7"
     enquirer "^1.0.3"
-    execa "^0.8.0"
+    execa "^0.9.0"
     fs-jetpack "^1.2.0"
     lodash.camelcase "^4.3.0"
     lodash.kebabcase "^4.1.1"
@@ -2637,7 +2647,7 @@ gluegun@^2.0.0-beta.4:
     lodash.trimstart "^4.5.1"
     lodash.uppercase "^4.3.0"
     lodash.upperfirst "^4.3.1"
-    ora "^1.2.0"
+    ora "^1.4.0"
     pluralize "^7.0.0"
     prompt-autocompletion "^0.1.1"
     prompt-checkbox "^2.2.0"
@@ -2650,9 +2660,9 @@ gluegun@^2.0.0-beta.4:
     prompt-rawlist "^2.0.1"
     ramda "^0.25.0"
     ramdasauce "^2.1.0"
-    semver "^5.3.0"
+    semver "^5.5.0"
     which "^1.2.14"
-    yargs-parser "^8.0.0"
+    yargs-parser "^9.0.2"
 
 gonzales-pe@^3.4.4:
   version "3.4.7"
@@ -4575,6 +4585,10 @@ nested-error-stacks@^2.0.0:
   dependencies:
     inherits "~2.0.1"
 
+nice-try@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
+
 no-case@^2.2.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
@@ -4829,7 +4843,7 @@ options@>=0.0.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/opts/-/opts-1.2.6.tgz#d185c0425cfdeb9da1d182908b65b5c0238febb3"
 
-ora@1.4.0:
+ora@1.4.0, ora@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ora/-/ora-1.4.0.tgz#884458215b3a5d4097592285f93321bb7a79e2e5"
   dependencies:
@@ -4847,7 +4861,7 @@ ora@^0.2.3:
     cli-spinners "^0.1.2"
     object-assign "^4.0.1"
 
-ora@^1.2.0, ora@^1.3.0:
+ora@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ora/-/ora-1.3.0.tgz#80078dd2b92a934af66a3ad72a5b910694ede51a"
   dependencies:
@@ -4975,12 +4989,6 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
-parse-json@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-3.0.0.tgz#fa6f47b18e23826ead32f263e744d0e1e847fb13"
-  dependencies:
-    error-ex "^1.3.1"
-
 parse-json@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
@@ -5038,7 +5046,7 @@ path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
@@ -5953,6 +5961,10 @@ semver-diff@^2.0.0:
 "semver@2 || 3 || 4 || 5", semver@5.4.1, semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.2.0, semver@^5.3.0, semver@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+
+semver@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 send@0.16.1:
   version "0.16.1"
@@ -7041,7 +7053,7 @@ yargs-parser@^7.0.0:
   dependencies:
     camelcase "^4.1.0"
 
-yargs-parser@^8.0.0, yargs-parser@^8.1.0:
+yargs-parser@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
   dependencies:


### PR DESCRIPTION
Upgrades to latest Gluegun beta.

Switches:

```js
import { print } from 'gluegun'
// to
import { print } from 'gluegun/toolbox'
```

(And similar require statements elsewhere in the code base)

Tests now pass, although that took a bit of messing around.

I also had to redefine all the extension types, since `strictNullChecks` was failing due to optional properties. Since they're all included, I made them required. Per https://github.com/infinitered/gluegun/issues/367.
