### PR TITLE
:rage3: windows working and fight node modules

### DIFF
--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -18,6 +18,7 @@
         "config",
         "configs",
         "custom",
+        "delineator",
         "docsify",
         "e.g.",
         "env",

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -47,6 +47,7 @@
         "specs",
         "tada",
         "tempy",
+        "typesync",
         "updtr",
         "v1",
         "walkthrough"

--- a/__tests__/__mocks__/mockContext.ts
+++ b/__tests__/__mocks__/mockContext.ts
@@ -9,6 +9,8 @@ const noConfigSolidarity = {
   setSolidaritySettings: jest.fn(),
   updateRequirement: jest.fn(),
   updateVersions: jest.fn(() => Promise.resolve()),
+  getLineWithVersion: jest.fn(),
+  removeNonVersionCharacters: jest.fn(),
 }
 
 const mockContext = {
@@ -16,6 +18,8 @@ const mockContext = {
   outputMode: undefined,
   system: {
     startTimer: jest.fn(() => jest.fn()),
+    run: jest.fn(() => '12'),
+    which: jest.fn((name) => 'usr/local/bin/${name}')
   },
   template: {
     generate: jest.fn(),

--- a/__tests__/__mocks__/mockContext.ts
+++ b/__tests__/__mocks__/mockContext.ts
@@ -19,7 +19,7 @@ const mockContext = {
   system: {
     startTimer: jest.fn(() => jest.fn()),
     run: jest.fn(() => '12'),
-    which: jest.fn((name) => 'usr/local/bin/${name}')
+    which: jest.fn(name => 'usr/local/bin/${name}'),
   },
   template: {
     generate: jest.fn(),

--- a/__tests__/command_helpers/checkCLI.ts
+++ b/__tests__/command_helpers/checkCLI.ts
@@ -9,6 +9,11 @@ const alwaysExistCLI = {
   binary: 'node',
 }
 
+const badSemver = {
+  binary: 'node',
+  semver: 'wtfbbq!!!11',
+}
+
 const outOfDateCLI = {
   binary: 'node',
   semver: '10.99',
@@ -22,6 +27,10 @@ test('error on missing binary', async () => {
 
 test('fine on existing binary', async () => {
   expect(await checkCLI(alwaysExistCLI, context)).toBe(undefined)
+})
+
+test('errors with message when an improper semver is sent', async () => {
+  expect(await checkCLI(badSemver, context)).toBe(`Invalid semver rule ${badSemver.semver}`)
 })
 
 test('returns message on improper version', async () => {

--- a/__tests__/command_helpers/getVersion.ts
+++ b/__tests__/command_helpers/getVersion.ts
@@ -13,7 +13,7 @@ describe('getVersion', () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000
   })
 
-  afterAll(function () {
+  afterAll(function() {
     // Fix timeout change
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout
   })

--- a/__tests__/command_helpers/quirksNodeModules.ts
+++ b/__tests__/command_helpers/quirksNodeModules.ts
@@ -1,0 +1,32 @@
+const path = require('path')
+const delineator = process.platform === 'win32' ? ';' : ':'
+test('quirks moves node_modules to back', () => {
+  // key is that it has `node_modules` + path.sep
+  const injectedStuff = `node_modules${path.sep}testOnly`
+  // prepend to PATH
+  process.env.PATH = injectedStuff + delineator + process.env.PATH
+  const pathAsArray = process.env.PATH.split(delineator)
+  // Yup it is prepended to front
+  expect(pathAsArray[0]).toBe(injectedStuff)
+  // require mutates PATH
+  require('../../src/extensions/functions/quirksNodeModules')
+  const newPathAsArray = process.env.PATH.split(delineator)
+  // Not in the front
+  expect(newPathAsArray[0]).not.toBe(injectedStuff)
+  // still there though (moved to back)
+  expect(process.env.PATH.includes(injectedStuff)).toBeTruthy()
+})
+
+test('quirks does not move just any injected path to back', () => {
+  const injectedStuff = `taco${path.sep}testOnly`
+  // prepend to PATH
+  process.env.PATH = injectedStuff + delineator + process.env.PATH
+  const pathAsArray = process.env.PATH.split(delineator)
+  // Yup it is prepended to front
+  expect(pathAsArray[0]).toBe(injectedStuff)
+  // require does not mutate PATH this time
+  require('../../src/extensions/functions/quirksNodeModules')
+  const newPathAsArray = process.env.PATH.split(delineator)
+  // Not in the front
+  expect(newPathAsArray[0]).toBe(injectedStuff)
+})

--- a/src/extensions/functions/checkCLI.ts
+++ b/src/extensions/functions/checkCLI.ts
@@ -2,6 +2,8 @@ import { SolidarityRunContext, CLIRule } from '../../types'
 module.exports = async (rule: CLIRule, context: SolidarityRunContext): Promise<string | undefined> => {
   const { semver, solidarity } = context
   const binaryExists = require('./binaryExists')
+  // Node Modules do strange things
+  require('./quirksNodeModules')
 
   // First check for binary
   if (!binaryExists(rule.binary, context)) {

--- a/src/extensions/functions/checkCLIForUpdates.ts
+++ b/src/extensions/functions/checkCLIForUpdates.ts
@@ -23,6 +23,7 @@ module.exports = async (rule: CLIRule, context: SolidarityRunContext): Promise<s
   // if it doesn't satisfy, upgrade
   if (rule.semver && !semver.satisfies(binarySemantic, rule.semver)) {
     rule.semver = binaryVersion
-    return print.colors.green(`Setting ${rule.binary} to '${binaryVersion}'`)
+    const lineMessage = rule.line ? ` line ${rule.line}` : ''
+    return print.colors.green(`Setting ${rule.binary}${lineMessage} to '${binaryVersion}'`)
   }
 }

--- a/src/extensions/functions/quirksNodeModules.ts
+++ b/src/extensions/functions/quirksNodeModules.ts
@@ -1,0 +1,11 @@
+import {
+  reject, contains, concat, difference
+} from 'ramda'
+import path from 'path'
+const delineator = process.platform === 'win32' ? ';' : ':'
+
+// Node mutates path by adding to the front, move that to the back if it exists
+const originalPath = process.env.PATH || ''
+const originalArray = originalPath.split(delineator)
+const cleanArray = reject(contains('node_modules' + path.sep), originalArray)
+process.env.PATH = concat(cleanArray, difference(originalArray, cleanArray)).join(delineator)

--- a/src/extensions/functions/quirksNodeModules.ts
+++ b/src/extensions/functions/quirksNodeModules.ts
@@ -1,7 +1,5 @@
-import {
-  reject, contains, concat, difference
-} from 'ramda'
-import path from 'path'
+import { reject, contains, concat, difference } from 'ramda'
+const path = require('path')
 const delineator = process.platform === 'win32' ? ';' : ':'
 
 // Node mutates path by adding to the front, move that to the back if it exists

--- a/src/extensions/functions/updateRequirement.ts
+++ b/src/extensions/functions/updateRequirement.ts
@@ -26,7 +26,8 @@ module.exports = async (
       case 'cli':
         if (!rule.semver) return []
         const updateResult = await checkCLIForUpdates(rule, context)
-        ruleString = `Keep ${rule.binary} ${rule.semver}`
+        const lineMessage = rule.line ? ` line ${rule.line} at` : ''
+        ruleString = `Keep ${rule.binary}${lineMessage} ${rule.semver}`
         if (updateResult) {
           spinner.succeed(updateResult)
           return updateResult


### PR DESCRIPTION
#### Node will inject its own bin to the front of `$PATH`, as identified in #175 

This simply moves that injection to the back to prefer global over anything `node_modules/`.

Tests included.  I attempted to go a wrong way first, and that left strange artifacts I had to clean up.  Squash to kill the noise

-----------------
Closes: #175 