### PR TITLE
Added repository link to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "solidarity",
   "version": "2.0.1",
   "description": "Make sure all React Native dependencies are uniform across machines",
+  "repository": "https://github.com/infinitered/solidarity",
   "bin": {
     "solidarity": "bin/solidarity"
   },


### PR DESCRIPTION
Fixes the missing link to the repository when running `yarn upgrade-interactive --latest`

<img width="882" alt="screen shot 2018-03-07 at 20 42 04" src="https://user-images.githubusercontent.com/310766/37114346-5e524560-2248-11e8-84cf-e9b92f21fe31.png">
