### PR TITLE
upgrade envinfo to 4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3281,9 +3281,9 @@
       "dev": true
     },
     "envinfo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-4.0.1.tgz",
-      "integrity": "sha512-p58/2vqK4kr81ZQCCFhoxJigRbgkaqnzu4qnNjJiS/K/PwstOWEi9JaUNayuI5tkJ4Eov7JhBis/dgbYEqZW/Q=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-4.3.1.tgz",
+      "integrity": "sha512-HdX4+D8bzsp5C5yTt+IUcSwl7YzRKIhB1pO3SPzMyLgnMBcFMg+fFyLZb5yBvZqN/ErxiibIyV5m1kse2eTbVQ=="
     },
     "errno": {
       "version": "0.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -652,11 +652,6 @@
         "default-require-extensions": "1.0.0"
       }
     },
-    "arch": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.0.tgz",
-      "integrity": "sha1-NhOqRhSQZLPB8GB5Gb8dR4boKIk="
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -709,15 +704,6 @@
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
-    },
-    "array-includes": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0"
-      }
     },
     "array-map": {
       "version": "0.0.0",
@@ -1348,7 +1334,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -1462,6 +1449,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -1818,41 +1806,6 @@
         "tiny-emitter": "2.0.2"
       }
     },
-    "clipboardy": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
-      "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
-      "requires": {
-        "arch": "2.1.0",
-        "execa": "0.8.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
-          }
-        },
-        "execa": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
-          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
-          "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          }
-        }
-      }
-    },
     "cliui": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
@@ -2183,7 +2136,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.1",
@@ -2603,6 +2557,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
       "requires": {
         "foreach": "2.0.5",
         "object-keys": "1.0.11"
@@ -3326,35 +3281,9 @@
       "dev": true
     },
     "envinfo": {
-      "version": "4.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-4.0.0-beta.7.tgz",
-      "integrity": "sha512-IFiFgioJfD16a2Ij18kc3p2TS+FBMynFErU8Xyj1LjRPl2t71VjzU2ZDymfNOJV3mp0csM9flakUb6Ovdzniyw==",
-      "requires": {
-        "array-includes": "3.0.3",
-        "clipboardy": "1.2.3",
-        "glob": "7.1.2",
-        "minimist": "1.2.0",
-        "object.entries": "1.0.4",
-        "object.values": "1.0.4",
-        "os-name": "2.0.1",
-        "which": "1.3.0",
-        "yamlify-object": "0.4.5"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        }
-      }
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-4.0.1.tgz",
+      "integrity": "sha512-p58/2vqK4kr81ZQCCFhoxJigRbgkaqnzu4qnNjJiS/K/PwstOWEi9JaUNayuI5tkJ4Eov7JhBis/dgbYEqZW/Q=="
     },
     "errno": {
       "version": "0.1.7",
@@ -3382,6 +3311,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+      "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
         "function-bind": "1.1.1",
@@ -3394,6 +3324,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
       "requires": {
         "is-callable": "1.1.3",
         "is-date-object": "1.0.1",
@@ -3859,7 +3790,8 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -5779,7 +5711,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "1.1.3",
@@ -6688,7 +6621,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "get-amd-module-type": {
       "version": "2.0.5",
@@ -7016,6 +6950,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
       "requires": {
         "function-bind": "1.1.1"
       }
@@ -7347,6 +7282,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -7360,7 +7296,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -7511,7 +7448,8 @@
     "is-callable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
     },
     "is-ci": {
       "version": "1.1.0",
@@ -7540,7 +7478,8 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "1.0.2",
@@ -7718,6 +7657,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
       "requires": {
         "has": "1.0.1"
       }
@@ -7748,7 +7688,8 @@
     "is-symbol": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -9425,11 +9366,6 @@
         "yallist": "2.1.2"
       }
     },
-    "macos-release": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
-      "integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA=="
-    },
     "madge": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/madge/-/madge-3.0.1.tgz",
@@ -9847,6 +9783,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "1.1.11"
       }
@@ -10363,7 +10300,8 @@
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -10371,17 +10309,6 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
         "isobject": "3.0.1"
-      }
-    },
-    "object.entries": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
-      "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.1"
       }
     },
     "object.getownpropertydescriptors": {
@@ -10415,17 +10342,6 @@
         }
       }
     },
-    "object.values": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
-      "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.1"
-      }
-    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -10439,6 +10355,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -10710,15 +10627,6 @@
         }
       }
     },
-    "os-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
-      "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
-      "requires": {
-        "macos-release": "1.1.0",
-        "win-release": "1.1.1"
-      }
-    },
     "os-shim": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
@@ -10892,7 +10800,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -14132,14 +14041,6 @@
         }
       }
     },
-    "win-release": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
-      "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
-      "requires": {
-        "semver": "5.5.0"
-      }
-    },
     "window-size": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-1.1.0.tgz",
@@ -14168,7 +14069,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "2.3.0",
@@ -14220,11 +14122,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
-    "yamlify-object": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/yamlify-object/-/yamlify-object-0.4.5.tgz",
-      "integrity": "sha512-5f6lMZ44N9vVSNFNBMmZ36LabURnMoDqWKj0dqP6IhlblmbeLSw/JN/So7+clwl/70CjmKxuJIb5eEyMQdZ55Q=="
     },
     "yargonaut": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "callsite": "^1.0.0",
-    "envinfo": "4.0.0-beta.7",
+    "envinfo": "^4.0.1",
     "gluegun": "2.0.0-beta.7",
     "json5": "^0.5.1",
     "minimist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "callsite": "^1.0.0",
-    "envinfo": "^4.0.1",
+    "envinfo": "^4.3.1",
     "gluegun": "2.0.0-beta.7",
     "json5": "^0.5.1",
     "minimist": "^1.2.0",

--- a/src/extensions/functions/solidarityReport.ts
+++ b/src/extensions/functions/solidarityReport.ts
@@ -1,12 +1,15 @@
 import { SolidarityRunContext, SolidarityReportResults, CLIReportConfig } from '../../types'
-import { helpers } from 'envinfo'
 
 export const createReport = (context: SolidarityRunContext): SolidarityReportResults => {
-  const { print, system } = context
+  const { print, system, envinfoHelpers } = context
   const { colors } = print
 
   return {
-    basicInfo: [['System Basics', 'Value'], ['OS', helpers.getOperatingSystemInfo()], ['CPU', helpers.getCPUInfo()]],
+    basicInfo: [
+      ['System Basics', 'Value'],
+      ['OS', envinfoHelpers.getOperatingSystemInfo()],
+      ['CPU', envinfoHelpers.getCPUInfo()],
+    ],
     cliRules: [['Binary', 'Location', 'Version', 'Desired']],
     envRules: [['Environment Var', 'Value']],
     filesystemRules: [['Location', 'Type', 'Exists']],

--- a/src/extensions/functions/solidarityReport.ts
+++ b/src/extensions/functions/solidarityReport.ts
@@ -1,15 +1,11 @@
 import { SolidarityRunContext, SolidarityReportResults, CLIReportConfig } from '../../types'
 
 export const createReport = (context: SolidarityRunContext): SolidarityReportResults => {
-  const { print, system, envinfoHelpers } = context
+  const { print, system, envInfo } = context
   const { colors } = print
 
   return {
-    basicInfo: [
-      ['System Basics', 'Value'],
-      ['OS', envinfoHelpers.getOperatingSystemInfo()],
-      ['CPU', envinfoHelpers.getCPUInfo()],
-    ],
+    basicInfo: [['System Basics', 'Value'], ['OS', envInfo.getOperatingSystemInfo()], ['CPU', envInfo.getCPUInfo()]],
     cliRules: [['Binary', 'Location', 'Version', 'Desired']],
     envRules: [['Environment Var', 'Value']],
     filesystemRules: [['Location', 'Type', 'Exists']],

--- a/src/extensions/solidarity-extension.ts
+++ b/src/extensions/solidarity-extension.ts
@@ -25,7 +25,7 @@ module.exports = (context: SolidarityRunContext): void => {
   }
 
   // Add helpers
-  context.envinfoHelpers = helpers
+  context.envInfo = helpers
 
   // Flavored separator
   context.printSeparator = (): void =>

--- a/src/extensions/solidarity-extension.ts
+++ b/src/extensions/solidarity-extension.ts
@@ -25,7 +25,7 @@ module.exports = (context: SolidarityRunContext): void => {
   }
 
   // Add helpers
-  context.envInfo = helpers
+  context.envinfoHelpers = helpers
 
   // Flavored separator
   context.printSeparator = (): void =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1947,9 +1947,9 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-envinfo@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-4.0.1.tgz#09ed5b7adce9b9e6956ef8bc9689e311d9a40991"
+envinfo@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-4.3.1.tgz#bcfa9341fa1e64dd416e07877c182a037c403eeb"
 
 errno@^0.1.3:
   version "0.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -488,10 +488,6 @@ aproba@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
 
-arch@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/arch/-/arch-2.1.0.tgz#3613aa46149064b3c1f0607919bf1d4786e82889"
-
 are-we-there-yet@~1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz#bb5dca382bb94f05e15194373d16fd3ba1ca110d"
@@ -536,13 +532,6 @@ array-filter@~0.0.0:
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
-
-array-includes@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.7.0"
 
 array-map@~0.0.0:
   version "0.0.0"
@@ -1218,13 +1207,6 @@ clipboard@^1.7.1:
     good-listener "^1.2.2"
     select "^1.1.2"
     tiny-emitter "^2.0.0"
-
-clipboardy@^1.2.2:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-1.2.3.tgz#0526361bf78724c1f20be248d428e365433c07ef"
-  dependencies:
-    arch "^2.1.0"
-    execa "^0.8.0"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -1965,19 +1947,9 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-envinfo@^4.0.0-beta.7:
-  version "4.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-4.0.0-beta.7.tgz#b663c6e7cf6c23fbfb26d77a9aa42794bf839960"
-  dependencies:
-    array-includes "^3.0.3"
-    clipboardy "^1.2.2"
-    glob "^7.1.2"
-    minimist "^1.2.0"
-    object.entries "^1.0.4"
-    object.values "^1.0.4"
-    os-name "^2.0.1"
-    which "^1.2.14"
-    yamlify-object "^0.4.5"
+envinfo@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-4.0.1.tgz#09ed5b7adce9b9e6956ef8bc9689e311d9a40991"
 
 errno@^0.1.3:
   version "0.1.6"
@@ -1995,7 +1967,7 @@ error-symbol@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/error-symbol/-/error-symbol-0.1.0.tgz#0a4dae37d600d15a29ba453d8ef920f1844333f6"
 
-es-abstract@^1.5.1, es-abstract@^1.6.1, es-abstract@^1.7.0:
+es-abstract@^1.5.1:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
   dependencies:
@@ -2477,7 +2449,7 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1:
+function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
@@ -4311,10 +4283,6 @@ lru-cache@^4.0.1, lru-cache@^4.1.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-macos-release@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-1.1.0.tgz#831945e29365b470aa8724b0ab36c8f8959d10fb"
-
 madge@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/madge/-/madge-3.0.1.tgz#c289ddc4b0e9d8f9f22f8464349a7d643dc021d5"
@@ -4759,15 +4727,6 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.entries@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.6.1"
-    function-bind "^1.1.0"
-    has "^1.0.1"
-
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
@@ -4781,15 +4740,6 @@ object.omit@^2.0.0, object.omit@~2.0.0:
   dependencies:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
-
-object.values@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.0.4.tgz#e524da09b4f66ff05df457546ec72ac99f13069a"
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.6.1"
-    function-bind "^1.1.0"
-    has "^1.0.1"
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -4887,13 +4837,6 @@ os-locale@^2.0.0:
     execa "^0.7.0"
     lcid "^1.0.0"
     mem "^1.1.0"
-
-os-name@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/os-name/-/os-name-2.0.1.tgz#b9a386361c17ae3a21736ef0599405c9a8c5dc5e"
-  dependencies:
-    macos-release "^1.0.0"
-    win-release "^1.0.0"
 
 os-shim@^0.1.2:
   version "0.1.3"
@@ -5962,7 +5905,7 @@ semver-diff@^2.0.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
-semver@^5.0.1, semver@^5.5.0:
+semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -6943,12 +6886,6 @@ widest-line@^2.0.0:
   dependencies:
     string-width "^2.1.1"
 
-win-release@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/win-release/-/win-release-1.1.1.tgz#5fa55e02be7ca934edfc12665632e849b72e5209"
-  dependencies:
-    semver "^5.0.1"
-
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
@@ -7021,10 +6958,6 @@ y18n@^3.2.1:
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
-
-yamlify-object@^0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/yamlify-object/-/yamlify-object-0.4.5.tgz#88291c64428d4aaf452141aaba6bda030d848f6c"
 
 yargonaut@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Envinfo needed to output a commonjs bundle to be imported this way. In the future I might make a selection of different bundles. 

I also needed to add a main entry in package.js, and have two entries in the dist/ folder - one for the main library and one for the cli. 

While I was at it, I got rid of the extra import we had in report, and just used envinfo from context. 