### PR TITLE
fix: retain semver symbols on snapshot update

### DIFF
--- a/__tests__/command_helpers/checkCLIForUpdates.ts
+++ b/__tests__/command_helpers/checkCLIForUpdates.ts
@@ -8,6 +8,13 @@ const rule = {
   version: '--version',
 }
 
+const ruleTildeSemver = {
+  rule: 'cli',
+  binary: 'npm',
+  semver: '~5.6.0',
+  version: '--version',
+}
+
 const ruleNoSemver = {
   rule: 'cli',
   binary: 'yarn',
@@ -49,6 +56,15 @@ describe('checkCLIForUpdates', () => {
       const result = await checkCLIForUpdates(ruleNoSemver, context)
       expect(result).toEqual(undefined)
       expect(ruleNoSemver.semver).toBe(undefined)
+    })
+
+    it('copies semver ~ symbol if present', async () => {
+      context.solidarity = {
+        getVersion: jest.fn(() => '5.8'),
+      }
+
+      const result = await checkCLIForUpdates(ruleTildeSemver, context)
+      expect(result).toEqual("Setting npm to '~5.8'")
     })
   })
 })

--- a/src/extensions/functions/checkCLIForUpdates.ts
+++ b/src/extensions/functions/checkCLIForUpdates.ts
@@ -20,10 +20,10 @@ module.exports = async (rule: CLIRule, context: SolidarityRunContext): Promise<s
     binarySemantic += '.0'
   }
 
-  // if it doesn't satisfy, upgrade
+  // if it doesn't satisfy, upgrade, and retain semver symbol
   if (rule.semver && !semver.satisfies(binarySemantic, rule.semver)) {
-    rule.semver = binaryVersion
+    rule.semver = `${/\^|\~/.test(rule.semver) ? rule.semver.charAt(0) : ''}${binaryVersion}`
     const lineMessage = rule.line ? ` line ${rule.line}` : ''
-    return print.colors.green(`Setting ${rule.binary}${lineMessage} to '${binaryVersion}'`)
+    return print.colors.green(`Setting ${rule.binary}${lineMessage} to '${rule.semver}'`)
   }
 }


### PR DESCRIPTION
Previously, this rule would update semver to "8.10.0" on `solidarity snapshot`, rather than the expected "~8.10.0". 

```
"Node": [
      {
        "rule": "cli",
        "binary": "node",
        "semver": "~8.9.4",
     }
]
```