### PR TITLE
disable travis buddy for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ notifications:
     urls:
       - 'https://www.travisbuddy.com/'
     on_success: never
-    on_failure: always
+    on_failure: never
     on_start: never
     on_cancel: never
     on_error: never


### PR DESCRIPTION
Both @jamonholmgren and @tabrindle have agreed, the bot must be disabled until it brings more value than "HEY NO" hehehe.  As it did in PR #185 

