### PR TITLE
Add relative path for plugin check

### DIFF
--- a/__tests__/command_helpers/checkSTDERR.ts
+++ b/__tests__/command_helpers/checkSTDERR.ts
@@ -10,4 +10,4 @@ describe('checkSTDERR', () => {
     expect(typeof output).toBe('string')
     expect(output.length).toBeGreaterThan(normal.length)
   })
-}
+})

--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -22,8 +22,8 @@ test('ensure build', async () => {
   expect(build().brand.mock.calls.length).toBe(1)
   expect(build().brand.mock.calls[0][0]).toBe('solidarity')
   expect(build().src.mock.calls.length).toBe(1)
-  // Check local and globals for Windows/Darwin === 3 checks
-  expect(build().plugins.mock.calls.length).toBe(3)
+  // Check local and globals for Windows/Darwin + Yarn === 4 checks
+  expect(build().plugins.mock.calls.length).toBe(4)
   expect(build().create.mock.calls.length).toBe(1)
   expect(build().run.mock.calls.length).toBe(1)
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { build } from 'gluegun'
+const os = require('os')
 
 module.exports = async (): Promise<void> => {
   // setup the runtime
@@ -9,6 +10,7 @@ module.exports = async (): Promise<void> => {
     .plugins('./node_modules', { matching: 'solidarity-*', hidden: true })
     // global installs
     .plugins('/usr/local/lib/node_modules', { matching: 'solidarity-*', hidden: true }) // Darwin
+    .plugins(`${os.homedir()}/.config/yarn/global/node_modules`, { matching: 'solidarity-*', hidden: true }) // Yarn/Darwin
     .plugins(`${process.env.appdata}/npm/node_modules`, { matching: 'solidarity-*', hidden: true }) // Windows
   // for testing - force load a local plugin
   // .plugin('../solidarity-react-native')


### PR DESCRIPTION
Tried it out by playing in `~/.config/yarn/global/node_modules/solidarity/dist/index.js`.

Seems to work out.

I first tried to put `~/.config/yarn/global/node_modules`, but this did not work (I guess `~` might not be the current user when `node` runs?)

Tentatively closes #221 