### PR TITLE
Refactored combined use of await and .then to use await only

### DIFF
--- a/src/extensions/functions/updateVersions.ts
+++ b/src/extensions/functions/updateVersions.ts
@@ -15,19 +15,18 @@ module.exports = async (context: SolidarityRunContext): Promise<void> => {
   )
 
   // run the array of promises you just created
-  await Promise.all(checks)
-    .then(results => {
-      const updates = flatten(results)
-      if (isEmpty(updates)) {
-        print.success('\n No Changes')
-      } else {
-        setSolidaritySettings(solidaritySettings, context)
-        const ruleMessage = pluralize('Rule', updates.length, true)
-        print.success(`\n ${ruleMessage} updated`)
-      }
-    })
-    .catch(err => {
-      print.error(err)
-      process.exit(2)
-    })
+  try {
+    const results = await Promise.all(checks);
+    const updates = flatten(results)
+    if (isEmpty(updates)) {
+      print.success('\n No Changes')
+    } else {
+      setSolidaritySettings(solidaritySettings, context)
+      const ruleMessage = pluralize('Rule', updates.length, true)
+      print.success(`\n ${ruleMessage} updated`)
+    }
+  } catch (err) {
+    print.error(err)
+    process.exit(2)
+  }
 }

--- a/src/extensions/functions/updateVersions.ts
+++ b/src/extensions/functions/updateVersions.ts
@@ -16,7 +16,7 @@ module.exports = async (context: SolidarityRunContext): Promise<void> => {
 
   // run the array of promises you just created
   try {
-    const results = await Promise.all(checks);
+    const results = await Promise.all(checks)
     const updates = flatten(results)
     if (isEmpty(updates)) {
       print.success('\n No Changes')


### PR DESCRIPTION
In the file /src/extensions/functions/updateVersions.ts, a combination of async/await and .then notation was used. Refactored that code to use async/await only. Closes #223 