### PR TITLE
Check the version subcommand as well

### DIFF
--- a/src/extensions/functions/getVersion.ts
+++ b/src/extensions/functions/getVersion.ts
@@ -15,7 +15,7 @@ module.exports = async (rule: CLIRule, context: SolidarityRunContext): Promise<s
     }
   } else {
     // We try the following in this order
-    // -v, --version, -version
+    // -v, --version, -version, version
     try {
       versionOutput = await system.run(`${rule.binary} -v`)
     } catch (_e) {
@@ -25,7 +25,11 @@ module.exports = async (rule: CLIRule, context: SolidarityRunContext): Promise<s
         try {
           versionOutput = await system.run(`${rule.binary} -version`)
         } catch (_e) {
-          throw 'No version identifier flag for this binary was found'
+          try {
+            versionOutput = await system.run(`${rule.binary} version`)
+          } catch (_e) {
+            throw 'No version identifier flag for this binary was found'
+          }
         }
       }
     }


### PR DESCRIPTION
helm (a kubernetes package manager) uses a version subcommand. I am not aware of any already installed binaries, which is why I didn't add a new test.